### PR TITLE
Suppress notifications while the app is active

### DIFF
--- a/index.html
+++ b/index.html
@@ -1178,7 +1178,20 @@ import { getFirestore, doc, setDoc, getDoc, collection, query, where, orderBy, o
                                 if (message.senderId !== user.uid) {
                                     const senderLogin = selectedChat.participantsData[message.senderId];
                                     const notifText = message.type === 'audio' ? '🎤 Голосовое сообщение' : message.text;
-                                    
+
+                                    const shouldShowNotification = () => {
+                                        if (typeof document === 'undefined') return true;
+                                        if (document.visibilityState === 'hidden') return true;
+                                        if (typeof document.hasFocus === 'function') {
+                                            return !document.hasFocus();
+                                        }
+                                        return false;
+                                    };
+
+                                    if (!shouldShowNotification()) {
+                                        return;
+                                    }
+
                                     if (navigator.serviceWorker && navigator.serviceWorker.controller) {
                                         navigator.serviceWorker.controller.postMessage({
                                             type: 'NEW_MESSAGE',


### PR DESCRIPTION
## Summary
- add visibility and focus checks before forwarding new message alerts to the service worker
- prevent push notifications from appearing while the messenger tab is active

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e52355303c8327a2e8d9b15fe17b9e