### PR TITLE
Route remote audio to earpiece

### DIFF
--- a/index.html
+++ b/index.html
@@ -159,7 +159,7 @@ import { getFirestore, doc, setDoc, getDoc, collection, query, where, orderBy, o
     <div id="root"></div>
 
     <script type="text/babel">
-        const { useState, useEffect, useRef } = React;
+        const { useState, useEffect, useRef, useCallback, useMemo } = React;
 
         function loginToEmail(login) {
             return `${login.toLowerCase()}@messenger.local`;
@@ -200,6 +200,11 @@ import { getFirestore, doc, setDoc, getDoc, collection, query, where, orderBy, o
             const [callState, setCallState] = useState(null);
             const [isMuted, setIsMuted] = useState(false);
             const [callDuration, setCallDuration] = useState(0);
+            const [audioOutputs, setAudioOutputs] = useState([]);
+            const [selectedAudioOutputId, setSelectedAudioOutputId] = useState('communications');
+            const [canSelectAudioOutput, setCanSelectAudioOutput] = useState(false);
+            const [audioRoutingError, setAudioRoutingError] = useState('');
+            const EARPIECE_FALLBACK_MESSAGE = 'Не удалось перевести звук в разговорный динамик, используется динамик по умолчанию.';
             
             const messageInputRef = useRef(null);
             const messagesEndRef = useRef(null);
@@ -276,21 +281,177 @@ import { getFirestore, doc, setDoc, getDoc, collection, query, where, orderBy, o
                 ]
             };
 
-            const routeRemoteAudioToEarpiece = async () => {
-                const audioEl = remoteAudioRef.current;
-                if (!audioEl) return;
+            const supportsNativeAudioPicker = useMemo(() => {
+                return typeof navigator !== 'undefined' &&
+                    navigator.mediaDevices &&
+                    typeof navigator.mediaDevices.selectAudioOutput === 'function';
+            }, []);
 
-                if (typeof audioEl.setSinkId === 'function') {
-                    try {
-                        await audioEl.setSinkId('communications');
-                        console.log('🔊 Аудио переведено в разговорный динамик через communications sink');
-                    } catch (error) {
-                        console.warn('⚠️ Не удалось переключить аудио в разговорный динамик:', error);
-                    }
-                } else {
-                    console.log('ℹ️ setSinkId не поддерживается в этом браузере');
+            const refreshAudioOutputs = useCallback(async () => {
+                if (!navigator.mediaDevices || !navigator.mediaDevices.enumerateDevices) {
+                    return;
                 }
+
+                try {
+                    const devices = await navigator.mediaDevices.enumerateDevices();
+                    const outputs = devices.filter(device => device.kind === 'audiooutput');
+                    setAudioOutputs(outputs);
+                } catch (error) {
+                    console.error('Ошибка получения устройств вывода:', error);
+                }
+            }, []);
+
+            const applyAudioOutput = useCallback(async (sinkId) => {
+                const audioEl = remoteAudioRef.current;
+                if (!audioEl) {
+                    return;
+                }
+
+                if (typeof audioEl.setSinkId !== 'function') {
+                    setCanSelectAudioOutput(false);
+                    setAudioRoutingError('Ваш браузер не поддерживает переключение устройства вывода звука.');
+                    return;
+                }
+
+                setCanSelectAudioOutput(true);
+
+                try {
+                    await audioEl.setSinkId(sinkId);
+                    setAudioRoutingError((prev) => {
+                        if (sinkId === 'default' && prev === EARPIECE_FALLBACK_MESSAGE) {
+                            return prev;
+                        }
+                        return '';
+                    });
+                    console.log(`🔊 Аудио переключено на устройство: ${sinkId}`);
+                } catch (error) {
+                    console.warn(`⚠️ Не удалось переключить аудио на ${sinkId}:`, error);
+                    if (sinkId === 'communications') {
+                        setAudioRoutingError(EARPIECE_FALLBACK_MESSAGE);
+                        setSelectedAudioOutputId('default');
+                    } else {
+                        setAudioRoutingError('Не удалось переключить устройство вывода звука.');
+                    }
+                }
+            }, []);
+
+            const handleRemoteAudioPlaybackStart = useCallback(async () => {
+                await refreshAudioOutputs();
+                await applyAudioOutput(selectedAudioOutputId);
+            }, [refreshAudioOutputs, applyAudioOutput, selectedAudioOutputId]);
+
+            const handleAudioOutputChange = (event) => {
+                setAudioRoutingError('');
+                setSelectedAudioOutputId(event.target.value);
             };
+
+            const openSystemAudioPicker = useCallback(async () => {
+                if (!supportsNativeAudioPicker) {
+                    setAudioRoutingError('Браузер не поддерживает системный выбор устройства вывода звука.');
+                    return;
+                }
+
+                try {
+                    const device = await navigator.mediaDevices.selectAudioOutput();
+                    if (device && device.deviceId) {
+                        setAudioRoutingError('');
+                        setSelectedAudioOutputId(device.deviceId);
+                    }
+                } catch (error) {
+                    if (error && error.name === 'AbortError') {
+                        console.log('Выбор устройства вывода отменён пользователем');
+                        return;
+                    }
+                    console.error('Ошибка выбора устройства вывода:', error);
+                    setAudioRoutingError('Не удалось выбрать устройство вывода звука.');
+                }
+            }, [supportsNativeAudioPicker]);
+
+            const audioOutputOptions = useMemo(() => {
+                const baseOptions = [
+                    { deviceId: 'communications', label: 'Разговорный динамик (если поддерживается)' },
+                    { deviceId: 'default', label: 'Системный динамик (по умолчанию)' }
+                ];
+
+                const seen = new Set(baseOptions.map(option => option.deviceId));
+
+                audioOutputs.forEach((device, index) => {
+                    if (!device.deviceId) {
+                        return;
+                    }
+
+                    const label = device.label ||
+                        (device.deviceId === 'default'
+                            ? 'Системный динамик (по умолчанию)'
+                            : `Устройство ${index + 1}`);
+
+                    if (seen.has(device.deviceId)) {
+                        if (device.deviceId === 'default') {
+                            baseOptions[1] = { deviceId: 'default', label };
+                        }
+                        return;
+                    }
+
+                    seen.add(device.deviceId);
+                    baseOptions.push({ deviceId: device.deviceId, label });
+                });
+
+                return baseOptions;
+            }, [audioOutputs]);
+
+            useEffect(() => {
+                refreshAudioOutputs();
+
+                if (!navigator.mediaDevices) {
+                    return;
+                }
+
+                const handler = () => {
+                    refreshAudioOutputs();
+                };
+
+                if (navigator.mediaDevices.addEventListener) {
+                    navigator.mediaDevices.addEventListener('devicechange', handler);
+                    return () => {
+                        navigator.mediaDevices.removeEventListener('devicechange', handler);
+                    };
+                }
+
+                const previousHandler = navigator.mediaDevices.ondevicechange;
+                navigator.mediaDevices.ondevicechange = handler;
+                return () => {
+                    if (navigator.mediaDevices.ondevicechange === handler) {
+                        navigator.mediaDevices.ondevicechange = previousHandler || null;
+                    }
+                };
+            }, [refreshAudioOutputs]);
+
+            useEffect(() => {
+                if (selectedAudioOutputId === 'communications' || selectedAudioOutputId === 'default') {
+                    return;
+                }
+
+                const exists = audioOutputs.some(device => device.deviceId === selectedAudioOutputId);
+                if (!exists) {
+                    if (audioOutputs.length > 0) {
+                        setSelectedAudioOutputId(audioOutputs[0].deviceId);
+                    } else {
+                        setSelectedAudioOutputId('default');
+                    }
+                }
+            }, [audioOutputs, selectedAudioOutputId]);
+
+            useEffect(() => {
+                applyAudioOutput(selectedAudioOutputId);
+            }, [selectedAudioOutputId, applyAudioOutput]);
+
+            useEffect(() => {
+                if (activeCall) {
+                    refreshAudioOutputs();
+                } else {
+                    setAudioRoutingError('');
+                }
+            }, [activeCall, refreshAudioOutputs]);
 
             const initiateCall = async (recipientId, recipientLogin) => {
                 try {
@@ -303,6 +464,7 @@ import { getFirestore, doc, setDoc, getDoc, collection, query, where, orderBy, o
                     
                     const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
                     localStreamRef.current = stream;
+                    await refreshAudioOutputs();
                     
                     const peerConnection = new RTCPeerConnection(iceServers);
                     peerConnectionRef.current = peerConnection;
@@ -411,13 +573,13 @@ import { getFirestore, doc, setDoc, getDoc, collection, query, where, orderBy, o
                                                 if (remoteAudioRef.current) {
                                                         console.log('✅ Audio элемент найден');
                                                         remoteAudioRef.current.srcObject = event.streams[0];
-
+                                                        handleRemoteAudioPlaybackStart();
                                                         remoteAudioRef.current.play()
                                                                 .then(() => {
                                                                         console.log('✅ Воспроизведение началось');
                                                                         console.log('📊 Громкость:', remoteAudioRef.current.volume);
                                                                         console.log('🔇 Muted:', remoteAudioRef.current.muted);
-                                                                        routeRemoteAudioToEarpiece();
+                                                                        handleRemoteAudioPlaybackStart();
                                                                 })
                                                                 .catch(err => {
                                                                         console.error('❌ Ошибка воспроизведения:', err);
@@ -508,7 +670,8 @@ import { getFirestore, doc, setDoc, getDoc, collection, query, where, orderBy, o
                     
                     const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
                     localStreamRef.current = stream;
-                    
+                    await refreshAudioOutputs();
+
                     const peerConnection = new RTCPeerConnection(iceServers);
                     peerConnectionRef.current = peerConnection;
 					
@@ -538,13 +701,13 @@ import { getFirestore, doc, setDoc, getDoc, collection, query, where, orderBy, o
                                                 if (remoteAudioRef.current) {
                                                         console.log('✅ Audio элемент найден');
                                                         remoteAudioRef.current.srcObject = event.streams[0];
-
+                                                        handleRemoteAudioPlaybackStart();
                                                         remoteAudioRef.current.play()
                                                                 .then(() => {
                                                                         console.log('✅ Воспроизведение началось');
                                                                         console.log('📊 Громкость:', remoteAudioRef.current.volume);
                                                                         console.log('🔇 Muted:', remoteAudioRef.current.muted);
-                                                                        routeRemoteAudioToEarpiece();
+                                                                        handleRemoteAudioPlaybackStart();
                                                                 })
                                                                 .catch(err => {
                                                                         console.error('❌ Ошибка воспроизведения:', err);
@@ -1721,6 +1884,43 @@ import { getFirestore, doc, setDoc, getDoc, collection, query, where, orderBy, o
                                         </p>
                                     </div>
                                     
+                                    {canSelectAudioOutput && (
+                                        <div className="mt-8 bg-white bg-opacity-10 rounded-2xl p-4 text-left">
+                                            <p className="text-sm text-white text-opacity-70 mb-3">
+                                                Куда выводить звук
+                                            </p>
+                                            <div className="space-y-3">
+                                                <select
+                                                    value={selectedAudioOutputId}
+                                                    onChange={handleAudioOutputChange}
+                                                    className="w-full bg-white bg-opacity-20 border border-white border-opacity-30 text-white rounded-xl px-4 py-3 focus:outline-none focus:ring-2 focus:ring-white focus:ring-opacity-70 backdrop-blur"
+                                                >
+                                                    {audioOutputOptions.map(option => (
+                                                        <option key={option.deviceId} value={option.deviceId}>
+                                                            {option.label}
+                                                        </option>
+                                                    ))}
+                                                </select>
+                                                {supportsNativeAudioPicker && (
+                                                    <button
+                                                        onClick={openSystemAudioPicker}
+                                                        className="w-full bg-white bg-opacity-20 hover:bg-opacity-30 text-white text-sm font-medium rounded-xl py-3 transition-colors backdrop-blur"
+                                                    >
+                                                        Открыть системное меню выбора
+                                                    </button>
+                                                )}
+                                                {audioRoutingError && (
+                                                    <p className="text-sm text-red-200">{audioRoutingError}</p>
+                                                )}
+                                            </div>
+                                        </div>
+                                    )}
+                                    {!canSelectAudioOutput && audioRoutingError && (
+                                        <div className="mt-8 bg-white bg-opacity-10 rounded-2xl p-4">
+                                            <p className="text-sm text-red-200 text-left">{audioRoutingError}</p>
+                                        </div>
+                                    )}
+
                                     <div className="flex justify-center space-x-6">
                                         <button
                                             onClick={toggleMute}

--- a/index.html
+++ b/index.html
@@ -276,6 +276,22 @@ import { getFirestore, doc, setDoc, getDoc, collection, query, where, orderBy, o
                 ]
             };
 
+            const routeRemoteAudioToEarpiece = async () => {
+                const audioEl = remoteAudioRef.current;
+                if (!audioEl) return;
+
+                if (typeof audioEl.setSinkId === 'function') {
+                    try {
+                        await audioEl.setSinkId('communications');
+                        console.log('🔊 Аудио переведено в разговорный динамик через communications sink');
+                    } catch (error) {
+                        console.warn('⚠️ Не удалось переключить аудио в разговорный динамик:', error);
+                    }
+                } else {
+                    console.log('ℹ️ setSinkId не поддерживается в этом браузере');
+                }
+            };
+
             const initiateCall = async (recipientId, recipientLogin) => {
                 try {
                     console.log('📞 Инициируем звонок к:', recipientLogin);
@@ -392,18 +408,19 @@ import { getFirestore, doc, setDoc, getDoc, collection, query, where, orderBy, o
 						
 						remoteStreamRef.current = event.streams[0];
 						
-						if (remoteAudioRef.current) {
-							console.log('✅ Audio элемент найден');
-							remoteAudioRef.current.srcObject = event.streams[0];
-							
-							remoteAudioRef.current.play()
-								.then(() => {
-									console.log('✅ Воспроизведение началось');
-									console.log('📊 Громкость:', remoteAudioRef.current.volume);
-									console.log('🔇 Muted:', remoteAudioRef.current.muted);
-								})
-								.catch(err => {
-									console.error('❌ Ошибка воспроизведения:', err);
+                                                if (remoteAudioRef.current) {
+                                                        console.log('✅ Audio элемент найден');
+                                                        remoteAudioRef.current.srcObject = event.streams[0];
+
+                                                        remoteAudioRef.current.play()
+                                                                .then(() => {
+                                                                        console.log('✅ Воспроизведение началось');
+                                                                        console.log('📊 Громкость:', remoteAudioRef.current.volume);
+                                                                        console.log('🔇 Muted:', remoteAudioRef.current.muted);
+                                                                        routeRemoteAudioToEarpiece();
+                                                                })
+                                                                .catch(err => {
+                                                                        console.error('❌ Ошибка воспроизведения:', err);
 								});
 						} else {
 							console.error('❌ Audio элемент НЕ найден!');
@@ -511,25 +528,26 @@ import { getFirestore, doc, setDoc, getDoc, collection, query, where, orderBy, o
                         peerConnection.addTrack(track, stream);
                     });
                     
-					peerConnection.ontrack = (event) => {
-						console.log('✅ Получен удаленный стрим');
-						console.log('📊 Треков в стриме:', event.streams[0].getTracks().length);
-						console.log('📊 Аудио треков:', event.streams[0].getAudioTracks().length);
-						
-						remoteStreamRef.current = event.streams[0];
-						
-						if (remoteAudioRef.current) {
-							console.log('✅ Audio элемент найден');
-							remoteAudioRef.current.srcObject = event.streams[0];
-							
-							remoteAudioRef.current.play()
-								.then(() => {
-									console.log('✅ Воспроизведение началось');
-									console.log('📊 Громкость:', remoteAudioRef.current.volume);
-									console.log('🔇 Muted:', remoteAudioRef.current.muted);
-								})
-								.catch(err => {
-									console.error('❌ Ошибка воспроизведения:', err);
+                                        peerConnection.ontrack = (event) => {
+                                                console.log('✅ Получен удаленный стрим');
+                                                console.log('📊 Треков в стриме:', event.streams[0].getTracks().length);
+                                                console.log('📊 Аудио треков:', event.streams[0].getAudioTracks().length);
+
+                                                remoteStreamRef.current = event.streams[0];
+
+                                                if (remoteAudioRef.current) {
+                                                        console.log('✅ Audio элемент найден');
+                                                        remoteAudioRef.current.srcObject = event.streams[0];
+
+                                                        remoteAudioRef.current.play()
+                                                                .then(() => {
+                                                                        console.log('✅ Воспроизведение началось');
+                                                                        console.log('📊 Громкость:', remoteAudioRef.current.volume);
+                                                                        console.log('🔇 Muted:', remoteAudioRef.current.muted);
+                                                                        routeRemoteAudioToEarpiece();
+                                                                })
+                                                                .catch(err => {
+                                                                        console.error('❌ Ошибка воспроизведения:', err);
 								});
 						} else {
 							console.error('❌ Audio элемент НЕ найден!');


### PR DESCRIPTION
## Summary
- add helper to route remote call audio to the communications audio sink
- invoke the routing when remote media starts playing for both caller and callee flows

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5ea01048483278adc89a23bf788cb