### PR TITLE
Inline data URI icons for PWA installability

### DIFF
--- a/index.html
+++ b/index.html
@@ -219,6 +219,7 @@ import { getFirestore, doc, setDoc, getDoc, collection, query, where, orderBy, o
             const localStreamRef = useRef(null);
             const remoteStreamRef = useRef(null);
             const remoteAudioRef = useRef(null);
+            const remoteAudioChainRef = useRef(null);
             const callTimerRef = useRef(null);
             const ringtoneRef = useRef(null);
             const ringtoneAudioRef = useRef(null);
@@ -316,6 +317,35 @@ import { getFirestore, doc, setDoc, getDoc, collection, query, where, orderBy, o
                     connectRingtoneToElement(ringtoneRef.current);
                 }
             }, [connectRingtoneToElement]);
+
+            const cleanupRemoteAudioChain = useCallback((options = {}) => {
+                const { clearElement = false } = options;
+                const chain = remoteAudioChainRef.current;
+
+                if (chain?.context && typeof chain.context.close === 'function') {
+                    try {
+                        const result = chain.context.close();
+                        if (result && typeof result.catch === 'function') {
+                            result.catch((error) => {
+                                console.warn('Ошибка закрытия аудио-контекста удалённого потока:', error);
+                            });
+                        }
+                    } catch (error) {
+                        console.warn('Ошибка закрытия аудио-контекста удалённого потока:', error);
+                    }
+                }
+
+                remoteAudioChainRef.current = null;
+
+                if (clearElement && remoteAudioRef.current) {
+                    try {
+                        remoteAudioRef.current.pause();
+                        remoteAudioRef.current.srcObject = null;
+                    } catch (error) {
+                        console.warn('Не удалось очистить audio элемент удалённого потока:', error);
+                    }
+                }
+            }, []);
 
             const iceServers = {
                 iceServers: [
@@ -499,8 +529,88 @@ import { getFirestore, doc, setDoc, getDoc, collection, query, where, orderBy, o
 
             const handleRemoteAudioPlaybackStart = useCallback(async () => {
                 await refreshAudioOutputs();
-                await applyAudioOutput(selectedAudioOutputId, { force: true });
+                await applyAudioOutput(selectedAudioOutputId, {
+                    force: true,
+                    requestPermission: selectedAudioOutputId === 'communications'
+                });
             }, [refreshAudioOutputs, applyAudioOutput, selectedAudioOutputId]);
+
+            const attachRemoteStream = useCallback(async (stream) => {
+                remoteStreamRef.current = stream;
+
+                const audioEl = remoteAudioRef.current;
+                if (!audioEl) {
+                    console.error('❌ Audio элемент НЕ найден!');
+                    return;
+                }
+
+                const AudioContextClass = window.AudioContext || window.webkitAudioContext;
+                let outputStream = stream;
+
+                if (AudioContextClass) {
+                    try {
+                        cleanupRemoteAudioChain();
+
+                        const audioContext = new AudioContextClass();
+                        if (audioContext.state === 'suspended') {
+                            try {
+                                await audioContext.resume();
+                            } catch (resumeError) {
+                                console.warn('⚠️ Не удалось активировать аудио-контекст перед моно-преобразованием:', resumeError);
+                            }
+                        }
+                        const source = audioContext.createMediaStreamSource(stream);
+                        const splitter = audioContext.createChannelSplitter(2);
+                        const merger = audioContext.createChannelMerger(1);
+
+                        const leftGain = audioContext.createGain();
+                        leftGain.gain.value = 0.5;
+                        splitter.connect(leftGain, 0);
+                        leftGain.connect(merger, 0, 0);
+
+                        if (splitter.numberOfOutputs > 1) {
+                            const rightGain = audioContext.createGain();
+                            rightGain.gain.value = 0.5;
+                            splitter.connect(rightGain, 1);
+                            rightGain.connect(merger, 0, 0);
+                        }
+
+                        const destination = audioContext.createMediaStreamDestination();
+                        merger.connect(destination);
+
+                        outputStream = destination.stream;
+                        remoteAudioChainRef.current = {
+                            context: audioContext,
+                            nodes: { source, splitter, merger }
+                        };
+
+                        console.log('🎧 Удалённый поток переведён в моно через Web Audio.');
+                    } catch (error) {
+                        console.warn('⚠️ Не удалось сконвертировать удалённый поток в моно:', error);
+                        cleanupRemoteAudioChain();
+                        outputStream = stream;
+                    }
+                } else {
+                    cleanupRemoteAudioChain();
+                }
+
+                try {
+                    audioEl.srcObject = outputStream;
+                    console.log('✅ Audio элемент найден и подключён к потоку');
+                } catch (error) {
+                    console.error('❌ Не удалось установить поток в audio элемент:', error);
+                    return;
+                }
+
+                await handleRemoteAudioPlaybackStart();
+
+                try {
+                    await audioEl.play();
+                    console.log('✅ Воспроизведение удалённого аудио началось');
+                } catch (error) {
+                    console.error('❌ Ошибка воспроизведения удалённого аудио:', error);
+                }
+            }, [cleanupRemoteAudioChain, handleRemoteAudioPlaybackStart]);
 
             const handleAudioOutputChange = async (event) => {
                 const newSinkId = event.target.value;
@@ -756,31 +866,13 @@ import { getFirestore, doc, setDoc, getDoc, collection, query, where, orderBy, o
 						}
 					};
                     
-					peerConnection.ontrack = (event) => {
-						console.log('✅ Получен удаленный стрим');
-						console.log('📊 Треков в стриме:', event.streams[0].getTracks().length);
-						console.log('📊 Аудио треков:', event.streams[0].getAudioTracks().length);
-						
-						remoteStreamRef.current = event.streams[0];
-						
-                                                if (remoteAudioRef.current) {
-                                                        console.log('✅ Audio элемент найден');
-                                                        remoteAudioRef.current.srcObject = event.streams[0];
-                                                        handleRemoteAudioPlaybackStart();
-                                                        remoteAudioRef.current.play()
-                                                                .then(() => {
-                                                                        console.log('✅ Воспроизведение началось');
-                                                                        console.log('📊 Громкость:', remoteAudioRef.current.volume);
-                                                                        console.log('🔇 Muted:', remoteAudioRef.current.muted);
-                                                                        handleRemoteAudioPlaybackStart();
-                                                                })
-                                                                .catch(err => {
-                                                                        console.error('❌ Ошибка воспроизведения:', err);
-								});
-						} else {
-							console.error('❌ Audio элемент НЕ найден!');
-						}
-					};
+                                        peerConnection.ontrack = (event) => {
+                                                console.log('✅ Получен удаленный стрим');
+                                                console.log('📊 Треков в стриме:', event.streams[0].getTracks().length);
+                                                console.log('📊 Аудио треков:', event.streams[0].getAudioTracks().length);
+
+                                                attachRemoteStream(event.streams[0]);
+                                        };
                     
 					const processedCandidates = new Set();
 					const candidatesUnsubscribe = onSnapshot(callRef, async (snapshot) => {
@@ -889,26 +981,8 @@ import { getFirestore, doc, setDoc, getDoc, collection, query, where, orderBy, o
                                                 console.log('📊 Треков в стриме:', event.streams[0].getTracks().length);
                                                 console.log('📊 Аудио треков:', event.streams[0].getAudioTracks().length);
 
-                                                remoteStreamRef.current = event.streams[0];
-
-                                                if (remoteAudioRef.current) {
-                                                        console.log('✅ Audio элемент найден');
-                                                        remoteAudioRef.current.srcObject = event.streams[0];
-                                                        handleRemoteAudioPlaybackStart();
-                                                        remoteAudioRef.current.play()
-                                                                .then(() => {
-                                                                        console.log('✅ Воспроизведение началось');
-                                                                        console.log('📊 Громкость:', remoteAudioRef.current.volume);
-                                                                        console.log('🔇 Muted:', remoteAudioRef.current.muted);
-                                                                        handleRemoteAudioPlaybackStart();
-                                                                })
-                                                                .catch(err => {
-                                                                        console.error('❌ Ошибка воспроизведения:', err);
-								});
-						} else {
-							console.error('❌ Audio элемент НЕ найден!');
-						}
-					};
+                                                attachRemoteStream(event.streams[0]);
+                                        };
                     
                     const { doc, getDoc, setDoc, updateDoc } = window.firebaseFunctions;
                     const callRef = doc(window.firebaseDb, 'calls', incomingCall.id);
@@ -1017,11 +1091,15 @@ import { getFirestore, doc, setDoc, getDoc, collection, query, where, orderBy, o
             const endCall = async () => {
                 try {
                     console.log('📞 Завершаем звонок');
-                    
+
                     stopRingtone();
-					
-					if (window.activeCallUnsubscribers && window.activeCallUnsubscribers.length > 0) {
-						console.log('🔌 Отписываемся от', window.activeCallUnsubscribers.length, 'подписок');
+
+                    cleanupRemoteAudioChain({ clearElement: true });
+                    remoteStreamRef.current = null;
+                    lastAppliedSinkRef.current = null;
+
+                                        if (window.activeCallUnsubscribers && window.activeCallUnsubscribers.length > 0) {
+                                                console.log('🔌 Отписываемся от', window.activeCallUnsubscribers.length, 'подписок');
 						window.activeCallUnsubscribers.forEach(unsub => {
 							try {
 								unsub();
@@ -1968,7 +2046,11 @@ import { getFirestore, doc, setDoc, getDoc, collection, query, where, orderBy, o
                     if (user) {
                         await removeFCMToken(user.uid);
                     }
-                    
+
+                    cleanupRemoteAudioChain({ clearElement: true });
+                    remoteStreamRef.current = null;
+                    lastAppliedSinkRef.current = null;
+
                     const { signOut } = window.firebaseFunctions;
                     await signOut(window.firebaseAuth);
                     setUser(null);

--- a/index.html
+++ b/index.html
@@ -203,15 +203,11 @@ import { getFirestore, doc, setDoc, getDoc, collection, query, where, orderBy, o
             const [isMuted, setIsMuted] = useState(false);
             const [callDuration, setCallDuration] = useState(0);
             const [audioOutputs, setAudioOutputs] = useState([]);
-            const [selectedAudioOutputId, setSelectedAudioOutputId] = useState(() => {
-                if (typeof HTMLMediaElement !== 'undefined' && typeof HTMLMediaElement.prototype.setSinkId === 'function') {
-                    return 'communications';
-                }
-                return 'default';
-            });
+            const [selectedAudioOutputId, setSelectedAudioOutputId] = useState('default');
+            const [speakerPermissionState, setSpeakerPermissionState] = useState('unknown');
             const [audioRoutingError, setAudioRoutingError] = useState('');
             const EARPIECE_FALLBACK_MESSAGE = 'Не удалось перевести звук в разговорный динамик, используется динамик по умолчанию.';
-            
+
             const messageInputRef = useRef(null);
             const messagesEndRef = useRef(null);
             const mediaRecorderRef = useRef(null);
@@ -226,6 +222,7 @@ import { getFirestore, doc, setDoc, getDoc, collection, query, where, orderBy, o
             const callTimerRef = useRef(null);
             const ringtoneRef = useRef(null);
             const ringtoneAudioRef = useRef(null);
+            const lastAppliedSinkRef = useRef(null);
 
             const isIOS = () => {
                 return /iPad|iPhone|iPod/.test(navigator.userAgent) || 
@@ -341,6 +338,39 @@ import { getFirestore, doc, setDoc, getDoc, collection, query, where, orderBy, o
                 return typeof HTMLMediaElement.prototype.setSinkId === 'function';
             }, []);
 
+            useEffect(() => {
+                if (!navigator?.permissions || !navigator.permissions.query) {
+                    return;
+                }
+
+                let permissionStatus = null;
+                let isMounted = true;
+
+                navigator.permissions.query({ name: 'speaker-selection' })
+                    .then((status) => {
+                        if (!isMounted) {
+                            return;
+                        }
+
+                        permissionStatus = status;
+                        setSpeakerPermissionState(status.state);
+
+                        status.onchange = () => {
+                            setSpeakerPermissionState(status.state);
+                        };
+                    })
+                    .catch((error) => {
+                        console.warn('Не удалось получить статус разрешения на выбор динамика:', error);
+                    });
+
+                return () => {
+                    isMounted = false;
+                    if (permissionStatus) {
+                        permissionStatus.onchange = null;
+                    }
+                };
+            }, []);
+
             const refreshAudioOutputs = useCallback(async () => {
                 if (!navigator.mediaDevices || !navigator.mediaDevices.enumerateDevices) {
                     return;
@@ -355,7 +385,61 @@ import { getFirestore, doc, setDoc, getDoc, collection, query, where, orderBy, o
                 }
             }, []);
 
-            const applyAudioOutput = useCallback(async (sinkId) => {
+            const ensureSpeakerPermission = useCallback(async () => {
+                if (!supportsSetSinkId) {
+                    return { granted: false };
+                }
+
+                if (speakerPermissionState === 'granted') {
+                    return { granted: true };
+                }
+
+                if (!navigator?.mediaDevices) {
+                    setAudioRoutingError('Браузер не предоставляет доступ к выбору устройства вывода.');
+                    return { granted: false };
+                }
+
+                if (navigator.permissions?.query && speakerPermissionState === 'denied') {
+                    setAudioRoutingError('Нет разрешения на выбор устройства вывода. Разрешите доступ в настройках браузера.');
+                    return { granted: false };
+                }
+
+                if (navigator.mediaDevices.selectAudioOutput) {
+                    try {
+                        const device = await navigator.mediaDevices.selectAudioOutput();
+                        await refreshAudioOutputs();
+                        setSpeakerPermissionState('granted');
+                        setAudioRoutingError('');
+                        return { granted: true, deviceId: device?.deviceId || null };
+                    } catch (error) {
+                        if (error?.name === 'AbortError') {
+                            console.log('Выбор устройства вывода отменён пользователем');
+                        } else if (error?.name === 'NotAllowedError' || error?.name === 'SecurityError') {
+                            setSpeakerPermissionState('denied');
+                            setAudioRoutingError('Нет разрешения на выбор устройства вывода. Разрешите доступ в настройках браузера.');
+                        } else {
+                            setAudioRoutingError('Не удалось запросить выбор устройства вывода звука.');
+                        }
+
+                        return { granted: false };
+                    }
+                }
+
+                setAudioRoutingError('Ваш браузер требует системный выбор устройства вывода. Используйте меню устройства.');
+                return { granted: false };
+            }, [supportsSetSinkId, speakerPermissionState, refreshAudioOutputs]);
+
+            const applyAudioOutput = useCallback(async (sinkId, options = {}) => {
+                if (!sinkId) {
+                    return;
+                }
+
+                const { force = false, requestPermission = false } = options;
+
+                if (!force && lastAppliedSinkRef.current === sinkId) {
+                    return;
+                }
+
                 const targets = [remoteAudioRef.current, ringtoneAudioRef.current].filter(Boolean);
                 if (targets.length === 0) {
                     return;
@@ -363,9 +447,23 @@ import { getFirestore, doc, setDoc, getDoc, collection, query, where, orderBy, o
 
                 if (!supportsSetSinkId) {
                     if (sinkId === 'communications') {
-                        setAudioRoutingError('Ваш браузер не позволяет перевести звук в разговорный динамик напрямую. Используйте системное меню ниже, чтобы выбрать нужное устройство.');
+                        setAudioRoutingError('Браузер не поддерживает перевод звука в разговорный динамик напрямую. Используйте системное меню устройства.');
+                    } else if (sinkId === 'default') {
+                        lastAppliedSinkRef.current = 'default';
                     }
                     return;
+                }
+
+                if (sinkId === 'communications') {
+                    if (requestPermission) {
+                        const { granted } = await ensureSpeakerPermission();
+                        if (!granted) {
+                            return;
+                        }
+                    } else if (speakerPermissionState !== 'granted') {
+                        console.log('🚫 Нет разрешения на использование разговорного динамика, пропускаем автоматическое применение.');
+                        return;
+                    }
                 }
 
                 let hadError = false;
@@ -375,29 +473,40 @@ import { getFirestore, doc, setDoc, getDoc, collection, query, where, orderBy, o
                         console.log(`🔊 Аудио переключено на устройство: ${sinkId}`);
                     } catch (error) {
                         console.warn(`⚠️ Не удалось переключить аудио на ${sinkId}:`, error);
-                        if (sinkId === 'communications') {
+
+                        if (error?.name === 'SecurityError' || error?.name === 'NotAllowedError') {
+                            setSpeakerPermissionState((current) => (current === 'denied' ? 'denied' : 'prompt'));
+                            if (sinkId === 'communications') {
+                                setAudioRoutingError('Нет доступа к разговорному динамику. Разрешите использование динамика или выберите устройство вручную.');
+                            } else {
+                                setAudioRoutingError('Нет доступа к выбранному устройству вывода. Разрешите использование динамиков в настройках.');
+                            }
+                        } else if (sinkId === 'communications') {
                             setAudioRoutingError(EARPIECE_FALLBACK_MESSAGE);
-                            setSelectedAudioOutputId('default');
                         } else {
                             setAudioRoutingError('Не удалось переключить устройство вывода звука.');
                         }
+
                         hadError = true;
                     }
                 }));
 
                 if (!hadError) {
+                    lastAppliedSinkRef.current = sinkId;
                     setAudioRoutingError('');
                 }
-            }, [supportsSetSinkId]);
+            }, [supportsSetSinkId, ensureSpeakerPermission, speakerPermissionState]);
 
             const handleRemoteAudioPlaybackStart = useCallback(async () => {
                 await refreshAudioOutputs();
-                await applyAudioOutput(selectedAudioOutputId);
+                await applyAudioOutput(selectedAudioOutputId, { force: true });
             }, [refreshAudioOutputs, applyAudioOutput, selectedAudioOutputId]);
 
-            const handleAudioOutputChange = (event) => {
+            const handleAudioOutputChange = async (event) => {
+                const newSinkId = event.target.value;
                 setAudioRoutingError('');
-                setSelectedAudioOutputId(event.target.value);
+                setSelectedAudioOutputId(newSinkId);
+                await applyAudioOutput(newSinkId, { force: true, requestPermission: newSinkId === 'communications' });
             };
 
             const openSystemAudioPicker = useCallback(async () => {
@@ -408,11 +517,14 @@ import { getFirestore, doc, setDoc, getDoc, collection, query, where, orderBy, o
 
                 try {
                     const device = await navigator.mediaDevices.selectAudioOutput();
+                    await refreshAudioOutputs();
+                    setSpeakerPermissionState('granted');
                     if (device && device.deviceId) {
                         setSelectedAudioOutputId(device.deviceId);
                         const matched = audioOutputs.find(output => output.deviceId === device.deviceId);
-                        if (matched?.label) {
-                            setAudioRoutingError(`Системой выбран вывод: ${matched.label}`);
+                        const label = device?.label || matched?.label;
+                        if (label) {
+                            setAudioRoutingError(`Системой выбран вывод: ${label}`);
                         } else {
                             setAudioRoutingError('Системой выбрано устройство вывода.');
                         }
@@ -425,7 +537,7 @@ import { getFirestore, doc, setDoc, getDoc, collection, query, where, orderBy, o
                     console.error('Ошибка выбора устройства вывода:', error);
                     setAudioRoutingError('Не удалось выбрать устройство вывода звука.');
                 }
-            }, [supportsNativeAudioPicker, audioOutputs]);
+            }, [supportsNativeAudioPicker, audioOutputs, refreshAudioOutputs]);
 
             const audioOutputOptions = useMemo(() => {
                 const baseOptions = supportsSetSinkId
@@ -514,6 +626,12 @@ import { getFirestore, doc, setDoc, getDoc, collection, query, where, orderBy, o
             useEffect(() => {
                 applyAudioOutput(selectedAudioOutputId);
             }, [selectedAudioOutputId, applyAudioOutput]);
+
+            useEffect(() => {
+                if (speakerPermissionState === 'granted' && selectedAudioOutputId === 'communications') {
+                    applyAudioOutput('communications', { force: true });
+                }
+            }, [speakerPermissionState, selectedAudioOutputId, applyAudioOutput]);
 
             useEffect(() => {
                 if (activeCall) {
@@ -1984,6 +2102,17 @@ import { getFirestore, doc, setDoc, getDoc, collection, query, where, orderBy, o
                                                             </option>
                                                         ))}
                                                     </select>
+                                                )}
+                                                {supportsSetSinkId && selectedAudioOutputId === 'communications' && speakerPermissionState !== 'granted' && (
+                                                    <button
+                                                        onClick={async () => {
+                                                            setAudioRoutingError('');
+                                                            await applyAudioOutput('communications', { force: true, requestPermission: true });
+                                                        }}
+                                                        className="w-full bg-white bg-opacity-20 hover:bg-opacity-30 text-white text-sm font-medium rounded-xl py-3 transition-colors backdrop-blur"
+                                                    >
+                                                        Разрешить вывод в разговорный динамик
+                                                    </button>
                                                 )}
                                                 {supportsNativeAudioPicker && (
                                                     <button

--- a/index.html
+++ b/index.html
@@ -225,6 +225,7 @@ import { getFirestore, doc, setDoc, getDoc, collection, query, where, orderBy, o
             const remoteAudioRef = useRef(null);
             const callTimerRef = useRef(null);
             const ringtoneRef = useRef(null);
+            const ringtoneAudioRef = useRef(null);
 
             const isIOS = () => {
                 return /iPad|iPhone|iPod/.test(navigator.userAgent) || 
@@ -248,25 +249,51 @@ import { getFirestore, doc, setDoc, getDoc, collection, query, where, orderBy, o
                 return deviceId;
             };
 
-            const createRingtone = () => {
+            const connectRingtoneToElement = useCallback((ringtone) => {
+                const audioEl = ringtoneAudioRef.current;
+                if (!audioEl || !ringtone) {
+                    return;
+                }
+
+                const { destination } = ringtone;
+                try {
+                    audioEl.srcObject = destination.stream;
+                    audioEl.muted = false;
+                    audioEl.loop = true;
+                    audioEl.play().catch((error) => {
+                        console.warn('Не удалось автоматически воспроизвести гудок:', error);
+                    });
+                } catch (error) {
+                    console.warn('Ошибка подключения гудка к audio элементу:', error);
+                }
+            }, []);
+
+            const createRingtone = useCallback(() => {
                 const audioContext = new (window.AudioContext || window.webkitAudioContext)();
                 const oscillator = audioContext.createOscillator();
                 const gainNode = audioContext.createGain();
-                
+                const destination = audioContext.createMediaStreamDestination();
+
                 oscillator.connect(gainNode);
-                gainNode.connect(audioContext.destination);
-                
+                gainNode.connect(destination);
+
+                oscillator.type = 'sine';
                 oscillator.frequency.value = 440;
-                gainNode.gain.value = 0.3;
-                
-                return { audioContext, oscillator, gainNode };
-            };
+                gainNode.gain.value = 0.2;
+
+                const ringtone = { audioContext, oscillator, gainNode, destination };
+                connectRingtoneToElement(ringtone);
+                return ringtone;
+            }, [connectRingtoneToElement]);
 
             const playRingtone = () => {
                 if (!ringtoneRef.current) {
                     ringtoneRef.current = createRingtone();
                     ringtoneRef.current.oscillator.start();
+                } else {
+                    connectRingtoneToElement(ringtoneRef.current);
                 }
+                applyAudioOutput(selectedAudioOutputId);
             };
 
             const stopRingtone = () => {
@@ -277,7 +304,21 @@ import { getFirestore, doc, setDoc, getDoc, collection, query, where, orderBy, o
                     } catch (e) {}
                     ringtoneRef.current = null;
                 }
+                if (ringtoneAudioRef.current) {
+                    try {
+                        ringtoneAudioRef.current.pause();
+                    } catch (e) {}
+                    ringtoneAudioRef.current.currentTime = 0;
+                    ringtoneAudioRef.current.srcObject = null;
+                    ringtoneAudioRef.current.muted = true;
+                }
             };
+
+            useEffect(() => {
+                if (ringtoneRef.current) {
+                    connectRingtoneToElement(ringtoneRef.current);
+                }
+            }, [connectRingtoneToElement]);
 
             const iceServers = {
                 iceServers: [
@@ -315,8 +356,8 @@ import { getFirestore, doc, setDoc, getDoc, collection, query, where, orderBy, o
             }, []);
 
             const applyAudioOutput = useCallback(async (sinkId) => {
-                const audioEl = remoteAudioRef.current;
-                if (!audioEl) {
+                const targets = [remoteAudioRef.current, ringtoneAudioRef.current].filter(Boolean);
+                if (targets.length === 0) {
                     return;
                 }
 
@@ -327,23 +368,25 @@ import { getFirestore, doc, setDoc, getDoc, collection, query, where, orderBy, o
                     return;
                 }
 
-                try {
-                    await audioEl.setSinkId(sinkId);
-                    setAudioRoutingError((prev) => {
-                        if (sinkId === 'default' && prev === EARPIECE_FALLBACK_MESSAGE) {
-                            return prev;
+                let hadError = false;
+                await Promise.all(targets.map(async (audioEl) => {
+                    try {
+                        await audioEl.setSinkId(sinkId);
+                        console.log(`🔊 Аудио переключено на устройство: ${sinkId}`);
+                    } catch (error) {
+                        console.warn(`⚠️ Не удалось переключить аудио на ${sinkId}:`, error);
+                        if (sinkId === 'communications') {
+                            setAudioRoutingError(EARPIECE_FALLBACK_MESSAGE);
+                            setSelectedAudioOutputId('default');
+                        } else {
+                            setAudioRoutingError('Не удалось переключить устройство вывода звука.');
                         }
-                        return '';
-                    });
-                    console.log(`🔊 Аудио переключено на устройство: ${sinkId}`);
-                } catch (error) {
-                    console.warn(`⚠️ Не удалось переключить аудио на ${sinkId}:`, error);
-                    if (sinkId === 'communications') {
-                        setAudioRoutingError(EARPIECE_FALLBACK_MESSAGE);
-                        setSelectedAudioOutputId('default');
-                    } else {
-                        setAudioRoutingError('Не удалось переключить устройство вывода звука.');
+                        hadError = true;
                     }
+                }));
+
+                if (!hadError) {
+                    setAudioRoutingError('');
                 }
             }, [supportsSetSinkId]);
 
@@ -1846,14 +1889,21 @@ import { getFirestore, doc, setDoc, getDoc, collection, query, where, orderBy, o
             if (user) {
                 return (
 					<React.Fragment>
-						{/* Audio элемент для звонков - всегда в DOM */}
-						<audio 
-							ref={remoteAudioRef} 
-							autoPlay 
-							playsInline
-							muted={false}
-							style={{ display: 'none' }}
-						/>
+                                                {/* Audio элементы для звонков - всегда в DOM */}
+                                                <audio
+                                                        ref={remoteAudioRef}
+                                                        autoPlay
+                                                        playsInline
+                                                        muted={false}
+                                                        style={{ display: 'none' }}
+                                                />
+                                                <audio
+                                                        ref={ringtoneAudioRef}
+                                                        autoPlay
+                                                        playsInline
+                                                        muted
+                                                        style={{ display: 'none' }}
+                                                />
                         {incomingCall && (
                             <div className="fixed inset-0 bg-black bg-opacity-90 flex items-center justify-center z-50 p-4">
                                 <div className="bg-white rounded-3xl p-8 max-w-sm w-full text-center">

--- a/index.html
+++ b/index.html
@@ -9,7 +9,9 @@
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="default">
     <link rel="manifest" href="/manifest.json">
-	<link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ccircle cx='50' cy='50' r='50' fill='%234F46E5'/%3E%3Ctext x='50' y='70' font-size='60' text-anchor='middle' fill='white' font-family='Arial, sans-serif' font-weight='bold'%3EM%3C/text%3E%3C/svg%3E">
+    <link rel="icon" type="image/svg+xml" sizes="192x192" href="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA1MTIgNTEyIj4KICA8ZGVmcz4KICAgIDxsaW5lYXJHcmFkaWVudCBpZD0iZyIgeDE9IjAiIHgyPSIxIiB5MT0iMCIgeTI9IjEiPgogICAgICA8c3RvcCBvZmZzZXQ9IjAlIiBzdG9wLWNvbG9yPSIjNjM2NkYxIi8+CiAgICAgIDxzdG9wIG9mZnNldD0iMTAwJSIgc3RvcC1jb2xvcj0iIzhCNUNGNiIvPgogICAgPC9saW5lYXJHcmFkaWVudD4KICA8L2RlZnM+CiAgPHJlY3QgeD0iMCIgeT0iMCIgd2lkdGg9IjUxMiIgaGVpZ2h0PSI1MTIiIHJ4PSIxMTIiIGZpbGw9InVybCgjZykiLz4KICA8cGF0aCBmaWxsPSIjZmZmIiBkPSJNMzUyIDE2MEgxNjBhMzIgMzIgMCAwIDAtMzIgMzJ2MTI4YTMyIDMyIDAgMCAwIDMyIDMyaDQ4bDQ4IDQ4IDQ4LTQ4aDQ4YTMyIDMyIDAgMCAwIDMyLTMyVjE5MmEzMiAzMiAwIDAgMC0zMi0zMnptLTEyOCAxNjAtMzItMzJoNjRsLTMyIDMyem05Ni02NGgtMzJ2LTMyaDMydjMyem0tNjQgMGgtMzJ2LTMyaDMydjMyem0tNjQgMGgtMzJ2LTMyaDMydjMyeiIvPgo8L3N2Zz4=">
+    <link rel="icon" type="image/svg+xml" sizes="512x512" href="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA1MTIgNTEyIj4KICA8ZGVmcz4KICAgIDxsaW5lYXJHcmFkaWVudCBpZD0iZyIgeDE9IjAiIHgyPSIxIiB5MT0iMCIgeTI9IjEiPgogICAgICA8c3RvcCBvZmZzZXQ9IjAlIiBzdG9wLWNvbG9yPSIjNjM2NkYxIi8+CiAgICAgIDxzdG9wIG9mZnNldD0iMTAwJSIgc3RvcC1jb2xvcj0iIzhCNUNGNiIvPgogICAgPC9saW5lYXJHcmFkaWVudD4KICA8L2RlZnM+CiAgPHJlY3QgeD0iMCIgeT0iMCIgd2lkdGg9IjUxMiIgaGVpZ2h0PSI1MTIiIHJ4PSIxMTIiIGZpbGw9InVybCgjZykiLz4KICA8cGF0aCBmaWxsPSIjZmZmIiBkPSJNMzUyIDE2MEgxNjBhMzIgMzIgMCAwIDAtMzIgMzJ2MTI4YTMyIDMyIDAgMCAwIDMyIDMyaDQ4bDQ4IDQ4IDQ4LTQ4aDQ4YTMyIDMyIDAgMCAwIDMyLTMyVjE5MmEzMiAzMiAwIDAgMC0zMi0zMnptLTEyOCAxNjAtMzItMzJoNjRsLTMyIDMyem05Ni02NGgtMzJ2LTMyaDMydjMyem0tNjQgMGgtMzJ2LTMyaDMydjMyem0tNjQgMGgtMzJ2LTMyaDMydjMyeiIvPgo8L3N2Zz4=">
+    <link rel="apple-touch-icon" href="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA1MTIgNTEyIj4KICA8ZGVmcz4KICAgIDxsaW5lYXJHcmFkaWVudCBpZD0iZyIgeDE9IjAiIHgyPSIxIiB5MT0iMCIgeTI9IjEiPgogICAgICA8c3RvcCBvZmZzZXQ9IjAlIiBzdG9wLWNvbG9yPSIjNjM2NkYxIi8+CiAgICAgIDxzdG9wIG9mZnNldD0iMTAwJSIgc3RvcC1jb2xvcj0iIzhCNUNGNiIvPgogICAgPC9saW5lYXJHcmFkaWVudD4KICA8L2RlZnM+CiAgPHJlY3QgeD0iMCIgeT0iMCIgd2lkdGg9IjUxMiIgaGVpZ2h0PSI1MTIiIHJ4PSIxMTIiIGZpbGw9InVybCgjZykiLz4KICA8cGF0aCBmaWxsPSIjZmZmIiBkPSJNMzUyIDE2MEgxNjBhMzIgMzIgMCAwIDAtMzIgMzJ2MTI4YTMyIDMyIDAgMCAwIDMyIDMyaDQ4bDQ4IDQ4IDQ4LTQ4aDQ4YTMyIDMyIDAgMCAwIDMyLTMyVjE5MmEzMiAzMiAwIDAgMC0zMi0zMnptLTEyOCAxNjAtMzItMzJoNjRsLTMyIDMyem05Ni02NGgtMzJ2LTMyaDMydjMyem0tNjQgMGgtMzJ2LTMyaDMydjMyem0tNjQgMGgtMzJ2LTMyaDMydjMyeiIvPgo8L3N2Zz4=">
     <title>Мессенджер</title>
     <script crossorigin src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
     <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
@@ -159,7 +161,7 @@ import { getFirestore, doc, setDoc, getDoc, collection, query, where, orderBy, o
     <div id="root"></div>
 
     <script type="text/babel">
-        const { useState, useEffect, useRef } = React;
+        const { useState, useEffect, useRef, useCallback, useMemo } = React;
 
         function loginToEmail(login) {
             return `${login.toLowerCase()}@messenger.local`;
@@ -200,6 +202,15 @@ import { getFirestore, doc, setDoc, getDoc, collection, query, where, orderBy, o
             const [callState, setCallState] = useState(null);
             const [isMuted, setIsMuted] = useState(false);
             const [callDuration, setCallDuration] = useState(0);
+            const [audioOutputs, setAudioOutputs] = useState([]);
+            const [selectedAudioOutputId, setSelectedAudioOutputId] = useState(() => {
+                if (typeof HTMLMediaElement !== 'undefined' && typeof HTMLMediaElement.prototype.setSinkId === 'function') {
+                    return 'communications';
+                }
+                return 'default';
+            });
+            const [audioRoutingError, setAudioRoutingError] = useState('');
+            const EARPIECE_FALLBACK_MESSAGE = 'Не удалось перевести звук в разговорный динамик, используется динамик по умолчанию.';
             
             const messageInputRef = useRef(null);
             const messagesEndRef = useRef(null);
@@ -276,6 +287,204 @@ import { getFirestore, doc, setDoc, getDoc, collection, query, where, orderBy, o
                 ]
             };
 
+            const supportsNativeAudioPicker = useMemo(() => {
+                return typeof navigator !== 'undefined' &&
+                    navigator.mediaDevices &&
+                    typeof navigator.mediaDevices.selectAudioOutput === 'function';
+            }, []);
+
+            const supportsSetSinkId = useMemo(() => {
+                if (typeof HTMLMediaElement === 'undefined') {
+                    return false;
+                }
+                return typeof HTMLMediaElement.prototype.setSinkId === 'function';
+            }, []);
+
+            const refreshAudioOutputs = useCallback(async () => {
+                if (!navigator.mediaDevices || !navigator.mediaDevices.enumerateDevices) {
+                    return;
+                }
+
+                try {
+                    const devices = await navigator.mediaDevices.enumerateDevices();
+                    const outputs = devices.filter(device => device.kind === 'audiooutput');
+                    setAudioOutputs(outputs);
+                } catch (error) {
+                    console.error('Ошибка получения устройств вывода:', error);
+                }
+            }, []);
+
+            const applyAudioOutput = useCallback(async (sinkId) => {
+                const audioEl = remoteAudioRef.current;
+                if (!audioEl) {
+                    return;
+                }
+
+                if (!supportsSetSinkId) {
+                    if (sinkId === 'communications') {
+                        setAudioRoutingError('Ваш браузер не позволяет перевести звук в разговорный динамик напрямую. Используйте системное меню ниже, чтобы выбрать нужное устройство.');
+                    }
+                    return;
+                }
+
+                try {
+                    await audioEl.setSinkId(sinkId);
+                    setAudioRoutingError((prev) => {
+                        if (sinkId === 'default' && prev === EARPIECE_FALLBACK_MESSAGE) {
+                            return prev;
+                        }
+                        return '';
+                    });
+                    console.log(`🔊 Аудио переключено на устройство: ${sinkId}`);
+                } catch (error) {
+                    console.warn(`⚠️ Не удалось переключить аудио на ${sinkId}:`, error);
+                    if (sinkId === 'communications') {
+                        setAudioRoutingError(EARPIECE_FALLBACK_MESSAGE);
+                        setSelectedAudioOutputId('default');
+                    } else {
+                        setAudioRoutingError('Не удалось переключить устройство вывода звука.');
+                    }
+                }
+            }, [supportsSetSinkId]);
+
+            const handleRemoteAudioPlaybackStart = useCallback(async () => {
+                await refreshAudioOutputs();
+                await applyAudioOutput(selectedAudioOutputId);
+            }, [refreshAudioOutputs, applyAudioOutput, selectedAudioOutputId]);
+
+            const handleAudioOutputChange = (event) => {
+                setAudioRoutingError('');
+                setSelectedAudioOutputId(event.target.value);
+            };
+
+            const openSystemAudioPicker = useCallback(async () => {
+                if (!supportsNativeAudioPicker) {
+                    setAudioRoutingError('Браузер не поддерживает системный выбор устройства вывода звука.');
+                    return;
+                }
+
+                try {
+                    const device = await navigator.mediaDevices.selectAudioOutput();
+                    if (device && device.deviceId) {
+                        setSelectedAudioOutputId(device.deviceId);
+                        const matched = audioOutputs.find(output => output.deviceId === device.deviceId);
+                        if (matched?.label) {
+                            setAudioRoutingError(`Системой выбран вывод: ${matched.label}`);
+                        } else {
+                            setAudioRoutingError('Системой выбрано устройство вывода.');
+                        }
+                    }
+                } catch (error) {
+                    if (error && error.name === 'AbortError') {
+                        console.log('Выбор устройства вывода отменён пользователем');
+                        return;
+                    }
+                    console.error('Ошибка выбора устройства вывода:', error);
+                    setAudioRoutingError('Не удалось выбрать устройство вывода звука.');
+                }
+            }, [supportsNativeAudioPicker, audioOutputs]);
+
+            const audioOutputOptions = useMemo(() => {
+                const baseOptions = supportsSetSinkId
+                    ? [
+                        { deviceId: 'communications', label: 'Разговорный динамик (если поддерживается)' },
+                        { deviceId: 'default', label: 'Системный динамик (по умолчанию)' }
+                    ]
+                    : [
+                        { deviceId: 'default', label: 'Системный динамик (по умолчанию)' }
+                    ];
+
+                const seen = new Set(baseOptions.map(option => option.deviceId));
+
+                audioOutputs.forEach((device, index) => {
+                    if (!device.deviceId) {
+                        return;
+                    }
+
+                    const label = device.label ||
+                        (device.deviceId === 'default'
+                            ? 'Системный динамик (по умолчанию)'
+                            : `Устройство ${index + 1}`);
+
+                    if (seen.has(device.deviceId)) {
+                        if (device.deviceId === 'default') {
+                            baseOptions[1] = { deviceId: 'default', label };
+                        }
+                        return;
+                    }
+
+                    seen.add(device.deviceId);
+                    baseOptions.push({ deviceId: device.deviceId, label });
+                });
+
+                return baseOptions;
+            }, [audioOutputs, supportsSetSinkId]);
+
+            useEffect(() => {
+                if (!supportsSetSinkId && selectedAudioOutputId === 'communications') {
+                    setSelectedAudioOutputId('default');
+                }
+            }, [supportsSetSinkId, selectedAudioOutputId]);
+
+            useEffect(() => {
+                refreshAudioOutputs();
+
+                if (!navigator.mediaDevices) {
+                    return;
+                }
+
+                const handler = () => {
+                    refreshAudioOutputs();
+                };
+
+                if (navigator.mediaDevices.addEventListener) {
+                    navigator.mediaDevices.addEventListener('devicechange', handler);
+                    return () => {
+                        navigator.mediaDevices.removeEventListener('devicechange', handler);
+                    };
+                }
+
+                const previousHandler = navigator.mediaDevices.ondevicechange;
+                navigator.mediaDevices.ondevicechange = handler;
+                return () => {
+                    if (navigator.mediaDevices.ondevicechange === handler) {
+                        navigator.mediaDevices.ondevicechange = previousHandler || null;
+                    }
+                };
+            }, [refreshAudioOutputs]);
+
+            useEffect(() => {
+                if (selectedAudioOutputId === 'communications' || selectedAudioOutputId === 'default') {
+                    return;
+                }
+
+                const exists = audioOutputs.some(device => device.deviceId === selectedAudioOutputId);
+                if (!exists) {
+                    if (audioOutputs.length > 0) {
+                        setSelectedAudioOutputId(audioOutputs[0].deviceId);
+                    } else {
+                        setSelectedAudioOutputId('default');
+                    }
+                }
+            }, [audioOutputs, selectedAudioOutputId]);
+
+            useEffect(() => {
+                applyAudioOutput(selectedAudioOutputId);
+            }, [selectedAudioOutputId, applyAudioOutput]);
+
+            useEffect(() => {
+                if (activeCall) {
+                    refreshAudioOutputs();
+                    if (!supportsSetSinkId && supportsNativeAudioPicker) {
+                        setAudioRoutingError('Ваш браузер переключает устройство вывода только через системное меню. Используйте кнопку ниже.');
+                    } else if (!supportsSetSinkId && !supportsNativeAudioPicker) {
+                        setAudioRoutingError('Браузер не позволяет переключать устройство вывода звука. Используется системный динамик.');
+                    }
+                } else {
+                    setAudioRoutingError('');
+                }
+            }, [activeCall, refreshAudioOutputs, supportsSetSinkId, supportsNativeAudioPicker]);
+
             const initiateCall = async (recipientId, recipientLogin) => {
                 try {
                     console.log('📞 Инициируем звонок к:', recipientLogin);
@@ -287,6 +496,7 @@ import { getFirestore, doc, setDoc, getDoc, collection, query, where, orderBy, o
                     
                     const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
                     localStreamRef.current = stream;
+                    await refreshAudioOutputs();
                     
                     const peerConnection = new RTCPeerConnection(iceServers);
                     peerConnectionRef.current = peerConnection;
@@ -392,18 +602,19 @@ import { getFirestore, doc, setDoc, getDoc, collection, query, where, orderBy, o
 						
 						remoteStreamRef.current = event.streams[0];
 						
-						if (remoteAudioRef.current) {
-							console.log('✅ Audio элемент найден');
-							remoteAudioRef.current.srcObject = event.streams[0];
-							
-							remoteAudioRef.current.play()
-								.then(() => {
-									console.log('✅ Воспроизведение началось');
-									console.log('📊 Громкость:', remoteAudioRef.current.volume);
-									console.log('🔇 Muted:', remoteAudioRef.current.muted);
-								})
-								.catch(err => {
-									console.error('❌ Ошибка воспроизведения:', err);
+                                                if (remoteAudioRef.current) {
+                                                        console.log('✅ Audio элемент найден');
+                                                        remoteAudioRef.current.srcObject = event.streams[0];
+                                                        handleRemoteAudioPlaybackStart();
+                                                        remoteAudioRef.current.play()
+                                                                .then(() => {
+                                                                        console.log('✅ Воспроизведение началось');
+                                                                        console.log('📊 Громкость:', remoteAudioRef.current.volume);
+                                                                        console.log('🔇 Muted:', remoteAudioRef.current.muted);
+                                                                        handleRemoteAudioPlaybackStart();
+                                                                })
+                                                                .catch(err => {
+                                                                        console.error('❌ Ошибка воспроизведения:', err);
 								});
 						} else {
 							console.error('❌ Audio элемент НЕ найден!');
@@ -491,7 +702,8 @@ import { getFirestore, doc, setDoc, getDoc, collection, query, where, orderBy, o
                     
                     const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
                     localStreamRef.current = stream;
-                    
+                    await refreshAudioOutputs();
+
                     const peerConnection = new RTCPeerConnection(iceServers);
                     peerConnectionRef.current = peerConnection;
 					
@@ -511,25 +723,26 @@ import { getFirestore, doc, setDoc, getDoc, collection, query, where, orderBy, o
                         peerConnection.addTrack(track, stream);
                     });
                     
-					peerConnection.ontrack = (event) => {
-						console.log('✅ Получен удаленный стрим');
-						console.log('📊 Треков в стриме:', event.streams[0].getTracks().length);
-						console.log('📊 Аудио треков:', event.streams[0].getAudioTracks().length);
-						
-						remoteStreamRef.current = event.streams[0];
-						
-						if (remoteAudioRef.current) {
-							console.log('✅ Audio элемент найден');
-							remoteAudioRef.current.srcObject = event.streams[0];
-							
-							remoteAudioRef.current.play()
-								.then(() => {
-									console.log('✅ Воспроизведение началось');
-									console.log('📊 Громкость:', remoteAudioRef.current.volume);
-									console.log('🔇 Muted:', remoteAudioRef.current.muted);
-								})
-								.catch(err => {
-									console.error('❌ Ошибка воспроизведения:', err);
+                                        peerConnection.ontrack = (event) => {
+                                                console.log('✅ Получен удаленный стрим');
+                                                console.log('📊 Треков в стриме:', event.streams[0].getTracks().length);
+                                                console.log('📊 Аудио треков:', event.streams[0].getAudioTracks().length);
+
+                                                remoteStreamRef.current = event.streams[0];
+
+                                                if (remoteAudioRef.current) {
+                                                        console.log('✅ Audio элемент найден');
+                                                        remoteAudioRef.current.srcObject = event.streams[0];
+                                                        handleRemoteAudioPlaybackStart();
+                                                        remoteAudioRef.current.play()
+                                                                .then(() => {
+                                                                        console.log('✅ Воспроизведение началось');
+                                                                        console.log('📊 Громкость:', remoteAudioRef.current.volume);
+                                                                        console.log('🔇 Muted:', remoteAudioRef.current.muted);
+                                                                        handleRemoteAudioPlaybackStart();
+                                                                })
+                                                                .catch(err => {
+                                                                        console.error('❌ Ошибка воспроизведения:', err);
 								});
 						} else {
 							console.error('❌ Audio элемент НЕ найден!');
@@ -1703,6 +1916,40 @@ import { getFirestore, doc, setDoc, getDoc, collection, query, where, orderBy, o
                                         </p>
                                     </div>
                                     
+                                    {(supportsSetSinkId || supportsNativeAudioPicker) && (
+                                        <div className="mt-8 bg-white bg-opacity-10 rounded-2xl p-4 text-left">
+                                            <p className="text-sm text-white text-opacity-70 mb-3">
+                                                Куда выводить звук
+                                            </p>
+                                            <div className="space-y-3">
+                                                {supportsSetSinkId && (
+                                                    <select
+                                                        value={selectedAudioOutputId}
+                                                        onChange={handleAudioOutputChange}
+                                                        className="w-full bg-white bg-opacity-20 border border-white border-opacity-30 text-white rounded-xl px-4 py-3 focus:outline-none focus:ring-2 focus:ring-white focus:ring-opacity-70 backdrop-blur"
+                                                    >
+                                                        {audioOutputOptions.map(option => (
+                                                            <option key={option.deviceId} value={option.deviceId}>
+                                                                {option.label}
+                                                            </option>
+                                                        ))}
+                                                    </select>
+                                                )}
+                                                {supportsNativeAudioPicker && (
+                                                    <button
+                                                        onClick={openSystemAudioPicker}
+                                                        className="w-full bg-white bg-opacity-20 hover:bg-opacity-30 text-white text-sm font-medium rounded-xl py-3 transition-colors backdrop-blur"
+                                                    >
+                                                        Открыть системное меню выбора
+                                                    </button>
+                                                )}
+                                                {audioRoutingError && (
+                                                    <p className="text-sm text-red-200">{audioRoutingError}</p>
+                                                )}
+                                            </div>
+                                        </div>
+                                    )}
+
                                     <div className="flex justify-center space-x-6">
                                         <button
                                             onClick={toggleMute}

--- a/manifest.json
+++ b/manifest.json
@@ -9,13 +9,13 @@
   "orientation": "portrait-primary",
   "icons": [
     {
-      "src": "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ccircle cx='50' cy='50' r='50' fill='%234F46E5'/%3E%3Ctext x='50' y='70' font-size='60' text-anchor='middle' fill='white' font-family='Arial, sans-serif' font-weight='bold'%3EM%3C/text%3E%3C/svg%3E",
+      "src": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA1MTIgNTEyIj4KICA8ZGVmcz4KICAgIDxsaW5lYXJHcmFkaWVudCBpZD0iZyIgeDE9IjAiIHgyPSIxIiB5MT0iMCIgeTI9IjEiPgogICAgICA8c3RvcCBvZmZzZXQ9IjAlIiBzdG9wLWNvbG9yPSIjNjM2NkYxIi8+CiAgICAgIDxzdG9wIG9mZnNldD0iMTAwJSIgc3RvcC1jb2xvcj0iIzhCNUNGNiIvPgogICAgPC9saW5lYXJHcmFkaWVudD4KICA8L2RlZnM+CiAgPHJlY3QgeD0iMCIgeT0iMCIgd2lkdGg9IjUxMiIgaGVpZ2h0PSI1MTIiIHJ4PSIxMTIiIGZpbGw9InVybCgjZykiLz4KICA8cGF0aCBmaWxsPSIjZmZmIiBkPSJNMzUyIDE2MEgxNjBhMzIgMzIgMCAwIDAtMzIgMzJ2MTI4YTMyIDMyIDAgMCAwIDMyIDMyaDQ4bDQ4IDQ4IDQ4LTQ4aDQ4YTMyIDMyIDAgMCAwIDMyLTMyVjE5MmEzMiAzMiAwIDAgMC0zMi0zMnptLTEyOCAxNjAtMzItMzJoNjRsLTMyIDMyem05Ni02NGgtMzJ2LTMyaDMydjMyem0tNjQgMGgtMzJ2LTMyaDMydjMyem0tNjQgMGgtMzJ2LTMyaDMydjMyeiIvPgo8L3N2Zz4=",
       "sizes": "192x192",
       "type": "image/svg+xml",
       "purpose": "any maskable"
     },
     {
-      "src": "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ccircle cx='50' cy='50' r='50' fill='%234F46E5'/%3E%3Ctext x='50' y='70' font-size='60' text-anchor='middle' fill='white' font-family='Arial, sans-serif' font-weight='bold'%3EM%3C/text%3E%3C/svg%3E",
+      "src": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA1MTIgNTEyIj4KICA8ZGVmcz4KICAgIDxsaW5lYXJHcmFkaWVudCBpZD0iZyIgeDE9IjAiIHgyPSIxIiB5MT0iMCIgeTI9IjEiPgogICAgICA8c3RvcCBvZmZzZXQ9IjAlIiBzdG9wLWNvbG9yPSIjNjM2NkYxIi8+CiAgICAgIDxzdG9wIG9mZnNldD0iMTAwJSIgc3RvcC1jb2xvcj0iIzhCNUNGNiIvPgogICAgPC9saW5lYXJHcmFkaWVudD4KICA8L2RlZnM+CiAgPHJlY3QgeD0iMCIgeT0iMCIgd2lkdGg9IjUxMiIgaGVpZ2h0PSI1MTIiIHJ4PSIxMTIiIGZpbGw9InVybCgjZykiLz4KICA8cGF0aCBmaWxsPSIjZmZmIiBkPSJNMzUyIDE2MEgxNjBhMzIgMzIgMCAwIDAtMzIgMzJ2MTI4YTMyIDMyIDAgMCAwIDMyIDMyaDQ4bDQ4IDQ4IDQ4LTQ4aDQ4YTMyIDMyIDAgMCAwIDMyLTMyVjE5MmEzMiAzMiAwIDAgMC0zMi0zMnptLTEyOCAxNjAtMzItMzJoNjRsLTMyIDMyem05Ni02NGgtMzJ2LTMyaDMydjMyem0tNjQgMGgtMzJ2LTMyaDMydjMyem0tNjQgMGgtMzJ2LTMyaDMydjMyeiIvPgo8L3N2Zz4=",
       "sizes": "512x512",
       "type": "image/svg+xml",
       "purpose": "any maskable"


### PR DESCRIPTION
## Summary
- replace the PWA icon references in the HTML head with inline SVG data URIs so no external image assets are required
- update the web manifest to serve the same inline SVG icons and drop the standalone icon files

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e5ea01048483278adc89a23bf788cb